### PR TITLE
fix: add missing library(blockr.dplyr) to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Add the AI chat interface to any board:
 
 ```r
 library(blockr.core)
+library(blockr.dplyr)
 library(blockr.ai)
 
 serve(


### PR DESCRIPTION
## Summary

- The quick-start README example used `new_filter_block()` without loading `blockr.dplyr`, causing a `could not find function` error for users following the docs
- Added `library(blockr.dplyr)` to the example

## Test plan

- [x] Copy the README quick-start snippet and confirm it runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)