### PR TITLE
Content-rich tool-call badges + dplyr flat-args eval

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.ai
 Title: AI-Powered Blocks for 'blockr.core'
-Version: 0.0.10
+Version: 0.0.11
 Authors@R:
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/R/ai-ctrl-block.R
+++ b/R/ai-ctrl-block.R
@@ -298,6 +298,44 @@ css_ai_ctrl <- function() {
       .blockr-ai-status-badge.phase-retrying {
         background-color: #fffbeb; border-color: #fde68a; color: #d97706;
       }
+      /* stack of per-tool-call badges (one per call, option A) */
+      .blockr-ai-status-stack {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 3px;
+      }
+      /* the one-line summary appended after a badge label */
+      .blockr-ai-status-summary {
+        font-weight: 400;
+        opacity: 0.85;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 240px;
+      }
+      .blockr-ai-status-summary code {
+        font-size: 0.92em;
+        background: rgba(0, 0, 0, 0.05);
+        padding: 0 3px;
+        border-radius: 3px;
+      }
+      .blockr-ai-status-sep { opacity: 0.45; }
+      .blockr-ai-status-icon svg { display: block; }
+      /* completed badge: drop the colour wash, go quiet/grey, keep the trace */
+      .blockr-ai-status-badge.is-done {
+        background-color: #fff;
+        border-color: #ececf0;
+        color: #9ca3af;
+      }
+      .blockr-ai-status-badge.is-done .blockr-ai-status-summary code {
+        background: var(--blockr-grey-100, #f3f4f6);
+      }
+      .blockr-ai-status-badge.is-done .blockr-ai-status-icon { color: #22c55e; }
+      .blockr-ai-status-badge.is-done.is-error {
+        background-color: #fffbeb;
+        border-color: #fde68a;
+        color: #b45309;
+      }
+      .blockr-ai-status-badge.is-error .blockr-ai-status-icon { color: #d97706; }
       .blockr-ai-status .markdown-stream-dot {
         display: none;
       }

--- a/R/harness-ellmer.R
+++ b/R/harness-ellmer.R
@@ -55,19 +55,6 @@ new_validate_tool <- function(validate, block, data = NULL) {
   # params can be inferred.
   types <- tryCatch(block_param_types(block), error = function(e) NULL)
   use_typed <- !is.null(types) && length(types) > 0
-  # When the schema unwrapped a `state = list(...)` block, the model is given
-  # state's children as flat args; re-wrap them under this key before validating.
-  wrap_key <- if (use_typed) attr(types, "wrap_key") else NULL
-  if (!is.null(wrap_key)) {
-    # Show the example unwrapped too, so it matches the flat schema.
-    child_ex <- tryCatch(attr(param_docs, "examples")[[wrap_key]],
-                         error = function(e) NULL)
-    if (!is.null(child_ex)) {
-      example_text <- paste0("\n\nExample config: ",
-        tryCatch(as.character(jsonlite::toJSON(child_ex, auto_unbox = TRUE)),
-                 error = function(e) ""))
-    }
-  }
 
   # Shared validation core: takes an already-parsed named list of block params.
   core_run <- function(args) {
@@ -128,8 +115,6 @@ new_validate_tool <- function(validate, block, data = NULL) {
   # (the polymorphic-array fallbacks) before validating.
   typed_run <- if (use_typed) {
     build_arg_collector(names(types), function(args) {
-      # Re-wrap state's children back under `state` (state-unwrap, see above).
-      if (!is.null(wrap_key)) args <- stats::setNames(list(args), wrap_key)
       core_run(tryCatch(simplify_leaves(reparse_json_strings(args)),
                         error = function(e) args))
     })

--- a/R/harness-ellmer.R
+++ b/R/harness-ellmer.R
@@ -271,6 +271,116 @@ build_tool_system_prompt <- function(var_names, block) {
 }
 
 
+#' Collapse a code probe to a one-line summary for a badge.
+#' @noRd
+summarize_probe_code <- function(code) {
+  code <- paste(code, collapse = " ")
+  code <- gsub("\\s+", " ", trimws(code))
+  truncate_summary(code, 64L)
+}
+
+#' Truncate a summary string with an ellipsis.
+#' @noRd
+truncate_summary <- function(x, n = 80L) {
+  if (is.null(x)) return("")
+  x <- gsub("\\s+", " ", trimws(as.character(x)))
+  if (length(x) != 1L) x <- paste(x, collapse = " ")
+  if (nchar(x) > n) paste0(substr(x, 1L, n - 1L), "…") else x
+}
+
+#' Build a reporter `tool_event` payload from an ellmer tool *request*.
+#'
+#' Fires when the model asks to call a tool, before it runs -- so the badge can
+#' appear immediately with a spinner and (for `data_tool`) the code it is about
+#' to run.
+#' @noRd
+tool_request_event <- function(request) {
+  name <- request@name
+  args <- request@arguments
+  if (identical(name, "data_tool")) {
+    list(id = request@id, phase = "exploring", label = "Exploring data",
+         summary = summarize_probe_code(args$code %||% ""), code = TRUE,
+         status = "active")
+  } else if (identical(name, "validate_config")) {
+    list(id = request@id, phase = "validating", label = "Applying configuration",
+         summary = NULL, code = FALSE, status = "active")
+  } else {
+    list(id = request@id, phase = "exploring", label = name, summary = NULL,
+         code = FALSE, status = "active")
+  }
+}
+
+#' Build a reporter `tool_event` payload from an ellmer tool *result*.
+#'
+#' Fires after the tool returns. Surfaces the genuinely useful content: for
+#' `validate_config`, the `effect` the config had (e.g. "rows 1200 -> 340") on
+#' success, or the validation error on failure. A thrown tool error (e.g. the
+#' data-probe budget being exceeded) lands in `@error`.
+#' @noRd
+tool_result_event <- function(result) {
+  request <- result@request
+  name <- request@name
+
+  if (!is.null(result@error) && nzchar(result@error %||% "")) {
+    return(list(id = request@id, phase = "retrying", label = "Fixing",
+                summary = truncate_summary(result@error), code = FALSE,
+                status = "error"))
+  }
+
+  value <- result@value
+  if (identical(name, "data_tool")) {
+    return(list(id = request@id, phase = "exploring", label = "Explored data",
+                summary = summarize_probe_code(request@arguments$code %||% ""),
+                code = TRUE, status = "done"))
+  }
+  if (identical(name, "validate_config")) {
+    ok <- is.list(value) && isTRUE(value$ok)
+    if (ok) {
+      return(list(id = request@id, phase = "confirming", label = "Applied config",
+                  summary = truncate_summary(value$effect %||% ""), code = FALSE,
+                  status = "done"))
+    }
+    err <- if (is.list(value)) value$error else NULL
+    return(list(id = request@id, phase = "retrying", label = "Fixing",
+                summary = truncate_summary(err %||% "invalid configuration"),
+                code = FALSE, status = "error"))
+  }
+  list(id = request@id, phase = "exploring", label = name, summary = NULL,
+       code = FALSE, status = "done")
+}
+
+#' Wire ellmer tool-call callbacks to a reporter.
+#'
+#' Registers request/result callbacks on the client so every tool call becomes a
+#' badge. Returns an unregister function (call it when the turn ends so a reused
+#' client does not accumulate callbacks bound to a stale reporter).
+#' @noRd
+register_tool_reporter <- function(client, reporter) {
+  noop <- function() invisible()
+  # Test/fake clients may not implement the tool-callback API; degrade quietly.
+  if (!is.function(client$on_tool_request) ||
+      !is.function(client$on_tool_result)) {
+    return(noop)
+  }
+  emit <- function(ev) {
+    if (!is.null(reporter$tool_event)) {
+      reporter$tool_event(ev$id, ev$phase, ev$label, ev$summary, ev$code,
+                          ev$status)
+    }
+  }
+  unreg_req <- client$on_tool_request(function(request) {
+    tryCatch(emit(tool_request_event(request)), error = function(e) NULL)
+  })
+  unreg_res <- client$on_tool_result(function(result) {
+    tryCatch(emit(tool_result_event(result)), error = function(e) NULL)
+  })
+  function() {
+    tryCatch(unreg_req(), error = function(e) NULL)
+    tryCatch(unreg_res(), error = function(e) NULL)
+  }
+}
+
+
 #' Discover block args via ellmer tool calling (Design A harness)
 #'
 #' @inheritParams discover_block_args
@@ -328,6 +438,11 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
   tools <- list(get_tool(validate_tool))
   if (!is.null(data_tool)) tools <- c(list(get_tool(data_tool)), tools)
   client$set_tools(tools)
+
+  # Surface every tool call as a reporter badge (the client is reused across
+  # turns, so unregister on exit to avoid stacking callbacks on a stale reporter).
+  unregister_reporter <- register_tool_reporter(client, reporter)
+  on.exit(unregister_reporter(), add = TRUE)
 
   # Send the full data schema on the first turn, and again whenever the upstream
   # data has CHANGED since we last sent it (the user may rewire the input between

--- a/R/param-schema.R
+++ b/R/param-schema.R
@@ -46,22 +46,6 @@ block_param_types <- function(block) {
     )
   }
 
-  # State-unwrap. blockr's `state = list(...)` convention wraps a block's whole
-  # config in one nested object. When `state` is the ONLY param, expose its
-  # first-order children as the AI's top-level arguments -- the model never sees
-  # (or has to correctly nest under) the `state` wrapper. The validate tool
-  # re-wraps them under `state` before applying (read via attr `wrap_key`). This
-  # lets blocks keep their natural `state` design instead of being flattened to
-  # suit the assistant.
-  if (identical(nms, "state") &&
-      inherits(types[["state"]], "ellmer::TypeObject")) {
-    children <- tryCatch(types[["state"]]@properties, error = function(e) NULL)
-    if (length(children)) {
-      attr(children, "wrap_key") <- "state"
-      return(children)
-    }
-  }
-
   types
 }
 
@@ -76,8 +60,8 @@ ellmer_type_from_default <- function(default, desc = "") {
 
 #' @noRd
 #' @param nested TRUE when typing a value INSIDE another object (vs a top-level
-#'   param). Top-level objects (notably `state`) must stay structs so they can be
-#'   unwrapped; the arbitrary-key-map heuristic only applies to nested values.
+#'   param). Top-level objects stay typed structs; the arbitrary-key-map
+#'   heuristic only applies to nested values.
 ellmer_type_from_value <- function(val, desc = "", nested = FALSE) {
   if (is.null(val) || is.data.frame(val)) {
     return(ellmer::type_string(desc, required = FALSE))
@@ -89,8 +73,8 @@ ellmer_type_from_value <- function(val, desc = "", nested = FALSE) {
       # A type_object would bake the example's keys in as fixed fields, so the
       # model copies them verbatim. When all values are scalars (a string/number/
       # bool map), pass it as a JSON-object string (arbitrary keys), re-parsed by
-      # the tool. Only for NESTED values -- a top-level all-scalar object (e.g.
-      # bind_rows state = {id_name}) is a struct that must stay unwrappable.
+      # the tool. Only for NESTED values -- a top-level all-scalar object is
+      # kept as a typed struct.
       # NOTE: the proper fix is in the BLOCK -- collections should be arrays of
       # fixed-field records (see mutate/summarize/rename), not data-keyed maps;
       # this heuristic only catches blocks that haven't been reshaped.

--- a/R/reporter.R
+++ b/R/reporter.R
@@ -3,6 +3,15 @@
 # Proxy objects that the discovery loop calls at each phase.
 # Three implementations: silent (benchmarks), console (interactive),
 # shiny (live chat feedback via shinychat).
+#
+# In addition to the coarse phase callbacks (start_phase/end_phase/done), the
+# reporter receives a `tool_event()` for every individual tool call the model
+# makes (one per `data_tool` probe, one per `validate_config`). The Shiny
+# reporter turns these into a stack of content-rich badges -- the tool's name
+# plus a one-line summary of what it did (the R snippet it ran, or the effect
+# the config had) -- so the user is notified of each step without the raw
+# tool-call dump the default shinychat UI shows.
+
 
 #' Progress reporter: silent
 #'
@@ -15,9 +24,26 @@ reporter_silent <- function() {
   list(
     start_phase  = function(phase, detail = NULL) {},
     update       = function(text) {},
+    tool_event   = function(id, phase, label, summary = NULL, code = FALSE,
+                            status = "active") {},
     end_phase    = function(phase, result = NULL) {},
     done         = function(success, message = NULL) {}
   )
+}
+
+
+#' Map a discovery phase to a human label.
+#' @noRd
+phase_label <- function(phase, detail = NULL) {
+  label <- switch(phase,
+    thinking   = "Analyzing",
+    exploring  = "Exploring data",
+    validating = "Applying configuration",
+    confirming = "Checking result",
+    retrying   = "Fixing",
+    phase
+  )
+  if (!is.null(detail)) paste0(label, ": ", detail) else label
 }
 
 
@@ -31,29 +57,30 @@ reporter_silent <- function() {
 reporter_console <- function() {
   list(
     start_phase = function(phase, detail = NULL) {
-      label <- switch(phase,
-        thinking   = "Analyzing",
-        exploring  = "Exploring data",
-        validating = "Validating",
-        confirming = "Checking result",
-        retrying   = "Retrying",
-        phase
-      )
-      if (!is.null(detail)) label <- paste0(label, ": ", detail)
-      cat(paste0("\u2192 ", label, "...\n"))
+      cat(paste0("→ ", phase_label(phase, detail), "...\n"))
     },
     update = function(text) {
       cat(paste0("  ", text, "\n"))
+    },
+    tool_event = function(id, phase, label, summary = NULL, code = FALSE,
+                          status = "active") {
+      # Only the resolved event is worth printing on the console (the request is
+      # immediately followed by its result in the synchronous loop).
+      if (identical(status, "active")) return(invisible())
+      mark <- if (identical(status, "error")) "✗" else "✓"
+      line <- paste0("  ", mark, " ", label)
+      if (!is.null(summary) && nzchar(summary)) line <- paste0(line, " · ", summary)
+      cat(line, "\n")
     },
     end_phase = function(phase, result = NULL) {
       if (!is.null(result)) cat(paste0("  ", result, "\n"))
     },
     done = function(success, message = NULL) {
       if (success) {
-        cat("\u2713 Done\n")
+        cat("✓ Done\n")
       } else {
         cat(paste0(
-          "\u2717 Failed",
+          "✗ Failed",
           if (!is.null(message)) paste0(": ", message),
           "\n"
         ))
@@ -63,12 +90,49 @@ reporter_console <- function() {
 }
 
 
+#' Bootstrap check icon (done state).
+#' @noRd
+blockr_ai_icon_check <- function() {
+  paste0(
+    '<svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" ',
+    'xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
+    '<path d="M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 ',
+    '1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 ',
+    '0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425a.247.247 0 0 1 ',
+    '.013-.014z"/></svg>'
+  )
+}
+
+#' Bootstrap exclamation-triangle icon (error/retry state).
+#' @noRd
+blockr_ai_icon_warn <- function() {
+  paste0(
+    '<svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" ',
+    'xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
+    '<path d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 ',
+    '0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06',
+    '.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054',
+    '-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044',
+    '-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713',
+    'c.889 0 1.438-.99.98-1.767z"/><path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 ',
+    '0M7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0z"/></svg>'
+  )
+}
+
+
 #' Progress reporter: Shiny
 #'
 #' Uses shinychat's chunk protocol to show live progress in the chat widget.
-#' Opens a single streaming assistant message and shows one active badge at a
-#' time using `operation = "replace"`. When `done()` is called the message is
-#' closed.
+#' Opens a single streaming assistant message and maintains an ordered *stack*
+#' of badges: a transient "Analyzing" badge while the model reasons, plus one
+#' content-rich badge per tool call (appended as each call fires -- option A).
+#' Each tool badge shows the tool's action and a one-line summary (the R snippet
+#' it ran, or the effect a config had). When the turn finishes the transient
+#' phase badges are dropped and the tool-call trace is left persisted in the
+#' transcript as a record of what the AI did.
+#'
+#' To switch to a single rolling badge (option B) instead of a stack, keep only
+#' the most recent tool item in `upsert()` -- the event plumbing is identical.
 #'
 #' @param chat_id The shinychat chat widget ID (namespaced)
 #' @param session The Shiny session
@@ -76,19 +140,59 @@ reporter_console <- function() {
 #' @export
 reporter_shiny <- function(chat_id, session) {
   streaming <- FALSE
-  active_label <- NULL
-  active_phase <- NULL
+  items <- list()  # ordered badge specs: list(id, phase, label, summary, code, status)
 
-  phase_label <- function(phase, detail = NULL) {
-    label <- switch(phase,
-      thinking   = "Analyzing",
-      exploring  = "Exploring data",
-      validating = "Applying configuration",
-      confirming = "Checking result",
-      retrying   = "Fixing",
-      phase
+  find_idx <- function(id) {
+    which(vapply(items, function(x) identical(x$id, id), logical(1)))
+  }
+  upsert <- function(spec) {
+    idx <- find_idx(spec$id)
+    if (length(idx)) items[[idx[1]]] <<- spec else items[[length(items) + 1L]] <<- spec
+  }
+  remove_item <- function(id) {
+    idx <- find_idx(id)
+    if (length(idx)) items[[idx[1]]] <<- NULL
+  }
+
+  status_icon <- function(status) {
+    inner <- switch(status,
+      active = shiny::tags$span(class = "spinner-border spinner-border-sm"),
+      error  = shiny::HTML(blockr_ai_icon_warn()),
+      shiny::HTML(blockr_ai_icon_check())
     )
-    if (!is.null(detail)) paste0(label, ": ", detail) else label
+    shiny::tags$span(class = "blockr-ai-status-icon", inner)
+  }
+
+  badge_tag <- function(spec) {
+    state_class <- switch(spec$status,
+      active = "is-active",
+      error  = "is-done is-error",
+      "is-done"
+    )
+    children <- list(status_icon(spec$status), spec$label)
+    if (!is.null(spec$summary) && nzchar(spec$summary)) {
+      summ <- if (isTRUE(spec$code)) shiny::tags$code(spec$summary) else spec$summary
+      children <- c(children, list(
+        shiny::tags$span(class = "blockr-ai-status-sep", "·"),
+        shiny::tags$span(class = "blockr-ai-status-summary", summ)
+      ))
+    }
+    do.call(shiny::tags$span, c(
+      list(class = paste("blockr-ai-status-badge", state_class,
+                         paste0("phase-", spec$phase))),
+      children
+    ))
+  }
+
+  render_html <- function() {
+    if (length(items) == 0L) {
+      shiny::tags$div(class = "blockr-ai-status blockr-ai-status-empty")
+    } else {
+      do.call(shiny::tags$div, c(
+        list(class = "blockr-ai-status blockr-ai-status-stack"),
+        lapply(items, badge_tag)
+      ))
+    }
   }
 
   ensure_open <- function() {
@@ -103,18 +207,16 @@ reporter_shiny <- function(chat_id, session) {
     }
   }
 
-  flush_and_close <- function() {
-    if (streaming) {
-      shinychat::chat_append_message(
-        chat_id,
-        list(role = "assistant", content = shiny::tags$div(
-          class = "blockr-ai-status blockr-ai-status-empty"
-        )),
-        chunk = "end",
-        session = session
-      )
-      streaming <<- FALSE
-    }
+  push <- function(final = FALSE) {
+    ensure_open()
+    shinychat::chat_append_message(
+      chat_id,
+      list(role = "assistant", content = render_html()),
+      chunk = if (final) "end" else TRUE,
+      operation = "replace",
+      session = session
+    )
+    if (final) streaming <<- FALSE
   }
 
   scroll_to_bottom <- function() {
@@ -123,47 +225,38 @@ reporter_shiny <- function(chat_id, session) {
     ))
   }
 
-  render <- function() {
-    ensure_open()
-    if (is.null(active_label)) {
-      html <- shiny::tags$div(class = "blockr-ai-status blockr-ai-status-empty")
-    } else {
-      badge <- shiny::tags$span(
-        class = paste("blockr-ai-status-badge is-active",
-                      paste0("phase-", active_phase)),
-        shiny::tags$span(
-          class = "blockr-ai-status-icon",
-          shiny::tags$span(class = "spinner-border spinner-border-sm")
-        ),
-        active_label
-      )
-      html <- shiny::tags$div(class = "blockr-ai-status", badge)
-    }
-    shinychat::chat_append_message(
-      chat_id,
-      list(role = "assistant", content = html),
-      chunk = TRUE,
-      operation = "replace",
-      session = session
-    )
-  }
-
   list(
     start_phase = function(phase, detail = NULL) {
-      active_phase <<- phase
-      active_label <<- phase_label(phase, detail)
-      render()
+      upsert(list(id = paste0("__phase_", phase), phase = phase,
+                  label = phase_label(phase, detail), summary = NULL,
+                  code = FALSE, status = "active"))
+      push()
       scroll_to_bottom()
     },
     update = function(text) {},
+    tool_event = function(id, phase, label, summary = NULL, code = FALSE,
+                          status = "active") {
+      upsert(list(id = id, phase = phase, label = label, summary = summary,
+                  code = code, status = status))
+      push()
+      scroll_to_bottom()
+    },
     end_phase = function(phase, result = NULL) {
-      active_phase <<- NULL
-      active_label <<- NULL
-      render()
+      remove_item(paste0("__phase_", phase))
+      push()
     },
     done = function(success, message = NULL) {
-      active_label <<- NULL
-      flush_and_close()
+      # Drop transient phase spinners; keep the tool-call trace persisted. Any
+      # tool still flagged active (shouldn't happen in the synchronous loop) is
+      # settled to done so nothing spins forever.
+      for (it in items) {
+        if (startsWith(it$id, "__phase_")) remove_item(it$id)
+      }
+      items <<- lapply(items, function(x) {
+        if (identical(x$status, "active")) x$status <- "done"
+        x
+      })
+      push(final = TRUE)
     }
   )
 }

--- a/dev/ai-eval-cases.md
+++ b/dev/ai-eval-cases.md
@@ -97,7 +97,7 @@ The cases split into three distinct problems; one fix does not solve all.
   Refinement: nudge to include each named domain as its own viz.
 
 ### D. OBSERVABILITY — output is not the meaningful artifact
-- **D1. drilldown block (blockr.bi)** — HARDEST. The block returns a **filtered
+- **D1. drilldown block (blockr.viz)** — HARDEST. The block returns a **filtered
   expr / passthrough data**, not the chart; the meaningful artifact (chart +
   drill bindings) lives in the JS CONTROL, not the R result
   (set_block_visibility(control=FALSE) hides it). So `data_effect` on the result
@@ -109,15 +109,15 @@ The cases split into three distinct problems; one fix does not solve all.
   representative drill and measure the downstream filtered data (data_effect on
   the applied filter); (c) image feedback — render the chart via the block's
   render path / Playwright and pass to `discover_block_args(images=)`.
-- **D2. crossfilter block (blockr.bi)** — reported CONTROL/wiring issues, "more
+- **D2. crossfilter block (blockr.viz)** — reported CONTROL/wiring issues, "more
   technical than prompting". Likely block-side, not the AI. Needs investigation
   before writing AI cases; may be a prerequisite bug, not a prompt-tuning target.
 - **Status:** DONE. drilldown 5/5 config GOOD from its rich registry prompt;
   built the OBSERVABILITY MECHANISM `config_effect(block, args, data)` (blockr.ai
-  effect.R generic; type-owner methods in blockr.bi/R/drilldown-ai-effect.R) —
+  effect.R generic; type-owner methods in blockr.viz/R/drilldown-ai-effect.R) —
   describes the chart spec + flags invalid column bindings + drill OFF; the
   validate tool uses it instead of the blind data effect. crossfilter (in
-  blockr.dm, not blockr.bi) 3/3 GOOD — the "control issue" flag was unfounded;
+  blockr.dm, not blockr.viz) 3/3 GOOD — the "control issue" flag was unfounded;
   its output IS the filtered data so data_effect works directly; model produces
   the correct nested per-table filter structure. ALL roster classes now covered.
 

--- a/dev/dplyr-eval-full.R
+++ b/dev/dplyr-eval-full.R
@@ -1,0 +1,54 @@
+# Broader blockr.dplyr eval across the COMPLEX blocks (polymorphic-array params)
+# whose registry `examples` carried the canonical shape. Run before/after the
+# flat-args registry migration to measure the example-shape lever.
+#   cd /tmp && Rscript --vanilla /workspace/blockr.ai/dev/dplyr-eval-full.R
+readRenviron("/workspace/.Renviron")
+.libPaths("/workspace/blockr.dev/.devcontainer/.library")
+suppressMessages({
+  pkgload::load_all("/workspace/blockr.dplyr", quiet = TRUE)
+  pkgload::load_all("/workspace/blockr.ai", quiet = TRUE)
+})
+MODEL <- "gpt-5.1"
+N <- 2  # runs per case (variance)
+`%||%` <- function(a, b) if (is.null(a) || !nzchar(as.character(a)[1])) b else a
+
+mtcars2 <- mtcars; mtcars2$car <- rownames(mtcars); rownames(mtcars2) <- NULL
+band <- dplyr::band_members; inst <- dplyr::band_instruments
+
+cases <- list(
+  list(nm = "filter-multi", blk = function() new_filter_block(), data = mtcars2,
+       ask = "Keep rows where mpg is greater than 20 AND cyl is less than 8."),
+  list(nm = "filter-values", blk = function() new_filter_block(), data = iris,
+       ask = "Keep only setosa and versicolor species."),
+  list(nm = "arrange-multi", blk = function() new_arrange_block(), data = mtcars2,
+       ask = "Sort by cyl ascending, then by mpg descending."),
+  list(nm = "mutate-grouped", blk = function() new_mutate_block(), data = mtcars2,
+       ask = "Add a column mean_mpg = the mean of mpg within each cyl group."),
+  list(nm = "summarize-grouped", blk = function() new_summarize_block(), data = mtcars2,
+       ask = "For each cyl, the average mpg and the number of rows.")
+)
+
+run_one <- function(cs) {
+  blk <- tryCatch(cs$blk(), error = function(e) e)
+  if (inherits(blk, "error")) return(paste("ctor-err:", conditionMessage(blk)))
+  client <- ellmer::chat_openai(model = MODEL, echo = "none")
+  args <- list(prompt = cs$ask, block = blk, data = cs$data, client = client)
+  res <- tryCatch(do.call(discover_block_args, args),
+                  error = function(e) list(success = FALSE, error = conditionMessage(e)))
+  if (isTRUE(res$success)) {
+    eff <- tryCatch(data_effect(cs$data, res$result),
+                    error = function(e) paste("eff-err:", conditionMessage(e)))
+    paste("OK:", substr(eff, 1, 110))
+  } else {
+    paste("FAIL/ASK:", substr(res$question %||% res$message %||% res$error %||% "(none)", 1, 130))
+  }
+}
+
+cat("============ DPLYR FULL (gpt-5.1) ============\n")
+for (cs in cases) {
+  for (k in seq_len(N)) {
+    out <- run_one(cs)
+    cat(sprintf("[%-18s #%d] %s\n", cs$nm, k, out))
+  }
+}
+cat("============ END ============\n")

--- a/dev/drilldown-eval-live.R
+++ b/dev/drilldown-eval-live.R
@@ -1,4 +1,4 @@
-# LIVE eval of the drilldown CHART block (blockr.bi) on gpt-5.1. Class D
+# LIVE eval of the drilldown CHART block (blockr.viz) on gpt-5.1. Class D
 # observability: result is a passthrough filter, so the artifact is the CHART
 # CONFIG. We score res$args (chart_type + column bindings) and print the new
 # config_effect feedback the model now receives.
@@ -7,9 +7,9 @@ readRenviron("/workspace/.Renviron")
 .libPaths("/workspace/blockr.dev/.devcontainer/.library")
 suppressMessages({
   pkgload::load_all("/workspace/blockr.ai", quiet = TRUE)   # ai first so bi's .onLoad can register config_effect
-  pkgload::load_all("/workspace/blockr.bi", quiet = TRUE)
+  pkgload::load_all("/workspace/blockr.viz", quiet = TRUE)
 })
-blockr.bi:::register_drilldown_ai_effect()
+blockr.viz:::register_drilldown_ai_effect()
 MODEL <- "gpt-5.1"
 `%||%` <- function(a, b) if (is.null(a) || (length(a) == 1 && !nzchar(as.character(a)))) b else a
 

--- a/dev/drilldown-eval-live.R
+++ b/dev/drilldown-eval-live.R
@@ -39,7 +39,7 @@ cases <- list(
 cat("================= DRILLDOWN CHART EVAL (gpt-5.1) =================\n")
 for (i in seq_along(cases)) {
   cs <- cases[[i]]
-  blk <- new_drilldown_chart_block()
+  blk <- new_chart_block()
   client <- ellmer::chat_openai(model = MODEL, echo = "none")
   res <- tryCatch(discover_block_args(prompt = cs$ask, block = blk, data = sales, client = client),
                   error = function(e) list(success = FALSE, error = conditionMessage(e)))

--- a/dev/drilldown-table-eval-live.R
+++ b/dev/drilldown-table-eval-live.R
@@ -43,7 +43,7 @@ cases <- list(
 cat("================= DRILLDOWN TABLE EVAL (gpt-5.1) =================\n")
 for (i in seq_along(cases)) {
   cs <- cases[[i]]
-  blk <- new_drilldown_table_block()
+  blk <- new_table_block()
   client <- ellmer::chat_openai(model = MODEL, echo = "none")
   res <- tryCatch(discover_block_args(prompt = cs$ask, block = blk, data = sales, client = client),
                   error = function(e) list(success = FALSE, error = conditionMessage(e)))

--- a/dev/drilldown-table-eval-live.R
+++ b/dev/drilldown-table-eval-live.R
@@ -1,4 +1,4 @@
-# LIVE eval of the drilldown TABLE block (blockr.bi) on gpt-5.1 -- the "badly
+# LIVE eval of the drilldown TABLE block (blockr.viz) on gpt-5.1 -- the "badly
 # tested" sibling of the drilldown chart. Class D observability: result is a
 # passthrough filter (row click filters downstream), so the artifact is the
 # CONFIG (label_col / value_cols / drill / transform). We score res$args and show
@@ -8,9 +8,9 @@ readRenviron("/workspace/.Renviron")
 .libPaths("/workspace/blockr.dev/.devcontainer/.library")
 suppressMessages({
   pkgload::load_all("/workspace/blockr.ai", quiet = TRUE)   # ai first so bi's .onLoad registers config_effect
-  pkgload::load_all("/workspace/blockr.bi", quiet = TRUE)
+  pkgload::load_all("/workspace/blockr.viz", quiet = TRUE)
 })
-blockr.bi:::register_drilldown_ai_effect()
+blockr.viz:::register_drilldown_ai_effect()
 MODEL <- "gpt-5.1"
 `%||%` <- function(a, b) if (is.null(a) || (length(a) == 1 && !nzchar(as.character(a)))) b else a
 

--- a/dev/harness-prompting-lessons.md
+++ b/dev/harness-prompting-lessons.md
@@ -46,7 +46,7 @@ registry and status. This doc is the **methodology + lessons**.
   hijacks `pkgload`). `--vanilla` skips `.Renviron`, so load the key explicitly:
   `readRenviron("/workspace/.Renviron")` (has `OPENAI_API_KEY`).
 - **Set the lib:** `.libPaths("/workspace/blockr.dev/.devcontainer/.library")`.
-- **Load order matters:** `blockr.extra` → `blockr.dm` → `blockr.sandbox`/`blockr.bi`
+- **Load order matters:** `blockr.extra` → `blockr.dm` → `blockr.sandbox`/`blockr.viz`
   → **`blockr.ai` last is wrong for runtime S3 registration**; load `blockr.ai`
   BEFORE the type-owner package whose `.onLoad` registers methods onto blockr.ai's
   generics (composer-ai-view, drilldown-ai-effect). When in doubt, call the
@@ -123,7 +123,7 @@ All in blockr.ai unless noted. Type-owner packages extend the generics.
 - **`config_effect(block, args, data)`** (`R/effect.R`): the OBSERVABILITY seam.
   For passthrough/control blocks, describe the CONFIG (and flag invalid column
   bindings) instead of the blind data effect; the validate tool uses it when
-  non-NULL. Type owners implement it (e.g. blockr.bi `drilldown-ai-effect.R`).
+  non-NULL. Type owners implement it (e.g. blockr.viz `drilldown-ai-effect.R`).
 - **Real error surfacing** (`R/discover.R`, `collect_block_errors`): a block that
   errors evaluating its expr returns NULL with the real error in
   `session$returned$cond$<stage>$error` (a `block_cnd` = a CHARACTER vector with a

--- a/dev/harness-prompting-lessons.md
+++ b/dev/harness-prompting-lessons.md
@@ -212,5 +212,21 @@ NOT work — populating/fixing the registry `examples` did.
 | crossfilter | B/D | 3/3 | already fine; "control issue" flag was unfounded |
 | topline flextable | B | columns 3/3; row-filter refusal unsolved | example-preference (arrays); refusal open |
 | stats model | B | 0 → 5/5 | reshaped block: formula AST → string + weights/offset as top-level args |
+| summary table | B | 3/5 → 5/5 (4 runs) | example carried only 6 of 9 `state` keys → `id_var`/`indent_details`/`nest_hierarchies` were INVISIBLE (state-unwrap exposes only example keys); added all 9 + sections-nesting + id_var-gating prose |
 
 Keep this and `ai-eval-cases.md` updated as more blocks are tested.
+
+### Summary-table lesson: the state-unwrap exposes ONLY the example's keys
+For a `state = list(...)` block, `block_param_types` builds the state object type
+from the registry **example**, then unwraps its children as the AI's top-level
+args. A constructor field that is absent from `examples$state` is therefore
+absent from the AI schema entirely — the model cannot set it however you prompt.
+The summary table's `id_var` (distinct-subject counts — a core pharma feature),
+`indent_details`, and `nest_hierarchies` were all missing from the example and so
+unreachable. Fix = put EVERY settable field in the example (use the EXCEPTION
+value, e.g. `id_var = ""`, not a populated one, to avoid over-triggering — a
+populated `id_var = "USUBJID"` made the model set it on every table). Two
+gating rules then carried the rest: (1) outer-categorical-goes-in-`sections`
+when one var nests in another (SOC>PT), and (2) set `id_var` only on an EXPLICIT
+distinct-patient request, never just because a USUBJID column exists.
+Eval script: `dev/summary-table-eval-live.R`.

--- a/dev/harness-prompting-lessons.md
+++ b/dev/harness-prompting-lessons.md
@@ -230,3 +230,26 @@ gating rules then carried the rest: (1) outer-categorical-goes-in-`sections`
 when one var nests in another (SOC>PT), and (2) set `id_var` only on an EXPLICIT
 distinct-patient request, never just because a USUBJID column exists.
 Eval script: `dev/summary-table-eval-live.R`.
+
+### Flat-args migration: re-key the registry `arguments`/`examples` to match
+When a block drops its single `state = list(...)` constructor argument for FLAT
+per-field args (blockr.dplyr 0.3.0 did this for all 13 blocks), the registry
+assistant metadata has to follow. `block_param_types` looks up `examples[[nm]]`
+and `docs[[nm]]` by the FORMAL name; if the registry still nests everything
+under `examples$state` / `c(state = "...")`, every lookup misses and:
+- the canonical example SHAPE (the single highest-leverage lever) is silently
+  dropped — polymorphic-array params (`conditions`, `summaries`, `keys`,
+  arrange `columns`) fall back to a bare "a JSON array string" leaf with no shape;
+- the tool description's `Parameters:`/`Example config:` prose still advertises a
+  `state` wrapper that no longer exists, contradicting the flat typed tool args.
+gpt-5.1 is robust enough to paper over this (filter/select/arrange/mutate/
+summarize all still passed 2/2 on the stale registry — the state-unwrap removal
+in `param-schema.R` plus the flat formals carry it), so the regression is latent,
+not loud. The fix is mechanical: flatten each `structure(c(state=...), examples=
+list(state=list(...)), prompt=...)` to `structure(c(field1=..., field2=...),
+examples=list(field1=..., field2=...), prompt=...)`, splitting the old
+"Object with: ..." blob into one description per field. The `prompt` prose is
+per-block and stays as-is. After flattening, `block_param_types` re-bakes the
+example shape into each array param's description (verify with
+`generate_example_json` + `block_param_types`). Eval: `dev/dplyr-eval-full.R`
+(filter-multi, filter-values, arrange-multi, mutate-grouped, summarize-grouped).

--- a/dev/summary-table-eval-live.R
+++ b/dev/summary-table-eval-live.R
@@ -1,0 +1,91 @@
+# LIVE eval of the summary table block (blockr.bi) on gpt-5.1. Class B/D: the
+# RESULT is a real tibble (the display-shaped summary), so we can score res$args
+# AND inspect the produced data frame. This is the "list of variables by Y"
+# (Table 1 / demographics, AE counts) block. The constructor takes a single
+# `state` list -> the harness state-unwrap exposes its children as top-level args
+# (only the keys present in the registry EXAMPLE are exposed!).
+#   cd /tmp && Rscript --vanilla /workspace/blockr.ai/dev/summary-table-eval-live.R
+readRenviron("/workspace/.Renviron")
+.libPaths("/workspace/blockr.dev/.devcontainer/.library")
+suppressMessages({
+  pkgload::load_all("/workspace/blockr.ai", quiet = TRUE)   # ai first
+  pkgload::load_all("/workspace/blockr.bi", quiet = TRUE)
+})
+blockr.bi::register_bi_blocks()
+MODEL <- "gpt-5.1"
+`%||%` <- function(a, b) if (is.null(a) || (length(a) == 1 && !nzchar(as.character(a)))) b else a
+
+# ----- data: ADaM-ish demographics (ADSL) + adverse events (ADAE) -----------
+set.seed(1)
+n_subj <- 80
+arms <- sample(c("Placebo", "Drug 6mg", "Drug 12mg"), n_subj, TRUE)
+adsl <- data.frame(
+  USUBJID = sprintf("S%03d", seq_len(n_subj)),
+  TRT01A  = arms,
+  AGE     = round(rnorm(n_subj, 62, 9)),
+  SEX     = sample(c("M", "F"), n_subj, TRUE),
+  RACE    = sample(c("WHITE", "BLACK", "ASIAN"), n_subj, TRUE, c(.7, .2, .1)),
+  BMIBL   = round(rnorm(n_subj, 27, 4), 1),
+  SAFFL   = sample(c(TRUE, FALSE), n_subj, TRUE, c(.95, .05)),
+  stringsAsFactors = FALSE
+)
+# Event-level AE: multiple rows per subject (the subject-dedup case).
+ae_rows <- do.call(rbind, lapply(seq_len(n_subj), function(i) {
+  k <- rpois(1, 2)
+  if (k == 0) return(NULL)
+  data.frame(
+    USUBJID = adsl$USUBJID[i], TRT01A = adsl$TRT01A[i],
+    AEBODSYS = sample(c("CARDIAC DISORDERS", "GI DISORDERS", "NERVOUS SYSTEM"), k, TRUE),
+    AEDECOD  = sample(c("HEADACHE", "NAUSEA", "DIZZINESS", "AF", "FLUTTER"), k, TRUE),
+    stringsAsFactors = FALSE
+  )
+}))
+
+cat("adsl cols:", paste(names(adsl), collapse = ", "), "\n")
+cat("adae cols:", paste(names(ae_rows), collapse = ", "),
+    "  (", nrow(ae_rows), "rows /", n_subj, "subjects )\n\n")
+
+# ----- cases: (prompt, data, checker on res$args) ---------------------------
+cases <- list(
+  list(nm = "demographics by arm", data = adsl[setdiff(names(adsl), "USUBJID")],
+       ask = "Show a demographics table of age, sex and race split by treatment arm, with an overall column.",
+       chk = function(a) all(c("AGE", "SEX", "RACE") %in% unlist(a$vars)) &&
+                         "TRT01A" %in% unlist(a$by) && isTRUE(a$add_overall) &&
+                         !nzchar(as.character(a$id_var %||% ""))),  # must NOT over-trigger dedup
+  list(nm = "expanded stats", data = adsl,
+       ask = "Baseline table of age and BMI by arm with full descriptive statistics (N, mean, SD, median, quartiles, min, max).",
+       chk = function(a) all(c("AGE", "BMIBL") %in% unlist(a$vars)) &&
+                         identical(as.character(a$stats %||% ""), "expanded")),
+  list(nm = "AE SOC/PT nested", data = ae_rows,
+       ask = "Adverse event counts by system organ class and preferred term, split by treatment.",
+       chk = function(a) "AEBODSYS" %in% unlist(a$sections) &&
+                         "AEDECOD" %in% unlist(a$vars) &&
+                         "TRT01A" %in% unlist(a$by)),
+  list(nm = "subject-dedup (id_var)", data = ae_rows,
+       ask = paste("Count adverse events by preferred term and treatment arm, but each subject",
+                   "should be counted at most once per term (distinct patients, not event rows).",
+                   "The subject identifier column is USUBJID."),
+       chk = function(a) identical(as.character(a$id_var %||% ""), "USUBJID")),
+  list(nm = "AE flag logical", data = transform(adsl, AETERMFL = SAFFL),
+       ask = "Summarise the SAFFL safety-population flag and sex by treatment arm.",
+       chk = function(a) "SAFFL" %in% unlist(a$vars) && "TRT01A" %in% unlist(a$by))
+)
+
+cat("================= SUMMARY TABLE EVAL (gpt-5.1) =================\n")
+n_ok <- 0
+for (i in seq_along(cases)) {
+  cs <- cases[[i]]
+  blk <- new_summary_table_block()
+  client <- ellmer::chat_openai(model = MODEL, echo = "none")
+  res <- tryCatch(
+    discover_block_args(prompt = cs$ask, block = blk, data = cs$data, client = client),
+    error = function(e) list(success = FALSE, error = conditionMessage(e)))
+  a <- res$args %||% list()
+  if (!is.null(a$state)) a <- a$state   # validate tool re-wraps unwrapped children under `state`
+  ok <- tryCatch(isTRUE(cs$chk(a)), error = function(e) FALSE)
+  n_ok <- n_ok + ok
+  cat(sprintf("\n[%d] %-6s %s\n", i, if (ok) "GOOD" else "MISS", cs$nm))
+  cat("    args:", substr(gsub("\\s+", " ", paste(utils::capture.output(str(a)), collapse = " ")), 1, 200), "\n")
+  if (!is.null(res$error)) cat("    error:", substr(res$error, 1, 120), "\n")
+}
+cat(sprintf("\n================= %d/%d GOOD =================\n", n_ok, length(cases)))

--- a/dev/summary-table-eval-live.R
+++ b/dev/summary-table-eval-live.R
@@ -1,4 +1,4 @@
-# LIVE eval of the summary table block (blockr.bi) on gpt-5.1. Class B/D: the
+# LIVE eval of the summary table block (blockr.viz) on gpt-5.1. Class B/D: the
 # RESULT is a real tibble (the display-shaped summary), so we can score res$args
 # AND inspect the produced data frame. This is the "list of variables by Y"
 # (Table 1 / demographics, AE counts) block. The constructor takes a single
@@ -9,9 +9,9 @@ readRenviron("/workspace/.Renviron")
 .libPaths("/workspace/blockr.dev/.devcontainer/.library")
 suppressMessages({
   pkgload::load_all("/workspace/blockr.ai", quiet = TRUE)   # ai first
-  pkgload::load_all("/workspace/blockr.bi", quiet = TRUE)
+  pkgload::load_all("/workspace/blockr.viz", quiet = TRUE)
 })
-blockr.bi::register_bi_blocks()
+blockr.viz::register_viz_blocks()
 MODEL <- "gpt-5.1"
 `%||%` <- function(a, b) if (is.null(a) || (length(a) == 1 && !nzchar(as.character(a)))) b else a
 

--- a/man/reporter_shiny.Rd
+++ b/man/reporter_shiny.Rd
@@ -16,7 +16,15 @@ A reporter list
 }
 \description{
 Uses shinychat's chunk protocol to show live progress in the chat widget.
-Opens a single streaming assistant message and shows one active badge at a
-time using \code{operation = "replace"}. When \code{done()} is called the message is
-closed.
+Opens a single streaming assistant message and maintains an ordered \emph{stack}
+of badges: a transient "Analyzing" badge while the model reasons, plus one
+content-rich badge per tool call (appended as each call fires -- option A).
+Each tool badge shows the tool's action and a one-line summary (the R snippet
+it ran, or the effect a config had). When the turn finishes the transient
+phase badges are dropped and the tool-call trace is left persisted in the
+transcript as a record of what the AI did.
+}
+\details{
+To switch to a single rolling badge (option B) instead of a stack, keep only
+the most recent tool item in \code{upsert()} -- the event plumbing is identical.
 }

--- a/tests/testthat/test-ai-ctrl-state.R
+++ b/tests/testthat/test-ai-ctrl-state.R
@@ -16,17 +16,15 @@ test_that("external state change propagates through block_server (filter)", {
       # Initial: no conditions, all 150 rows
       expect_equal(nrow(session$returned$result()), 150)
 
-      # Simulate what AI ctrl does: set state externally
+      # Simulate what AI ctrl does: set state externally (per-field reactiveVals)
       state <- session$returned$state
-      state$state(list(
-        conditions = list(
-          list(
-            type = "values", column = "Species",
-            values = c("virginica"), mode = "include"
-          )
-        ),
-        operator = "&"
+      state$conditions(list(
+        list(
+          type = "values", column = "Species",
+          values = c("virginica"), mode = "include"
+        )
       ))
+      state$operator("&")
       session$flushReact()
 
       # Should now be 50 rows — if not, the bug is reproduced
@@ -48,15 +46,13 @@ test_that("external state change with exclude mode (filter)", {
       expect_equal(nrow(session$returned$result()), 150)
 
       state <- session$returned$state
-      state$state(list(
-        conditions = list(
-          list(
-            type = "values", column = "Species",
-            values = c("setosa"), mode = "exclude"
-          )
-        ),
-        operator = "&"
+      state$conditions(list(
+        list(
+          type = "values", column = "Species",
+          values = c("setosa"), mode = "exclude"
+        )
       ))
+      state$operator("&")
       session$flushReact()
 
       result <- session$returned$result()
@@ -79,12 +75,10 @@ test_that("external state change with numeric values (filter)", {
       expect_equal(nrow(session$returned$result()), 32)
 
       state <- session$returned$state
-      state$state(list(
-        conditions = list(
-          list(type = "numeric", column = "cyl", op = "is", value = 4)
-        ),
-        operator = "&"
+      state$conditions(list(
+        list(type = "numeric", column = "cyl", op = "is", value = 4)
       ))
+      state$operator("&")
       session$flushReact()
 
       result <- session$returned$result()


### PR DESCRIPTION
## Summary

- **Content-rich tool-call badges** in the chat assistant: each tool call the assistant makes is surfaced as its own badge with a one-line summary (the R snippet a data probe ran, or the effect a config had) instead of the single uninformative "Analyzing" spinner. Driven by ellmer's `on_tool_request`/`on_tool_result` callbacks; badges stack live (one per call) and persist as a compact trace after the turn.
- **dplyr flat-args migration**: drop the single-state flattening from the param schema and the re-wrap-before-validate step in the ellmer harness now that the dplyr blocks expose flat per-field args. Keep the nested data-keyed-map fallback. Migrate `test-ai-ctrl-state` to per-field state setters.
  - NOTE: blocks still using `state = list(...)` (blockr.viz, blockr.input) regress to an opaque state object until they are flattened too.
- **dplyr flat-args eval** (`dev/dplyr-eval-full.R`) covering the complex dplyr blocks (filter, arrange, mutate, summarize); document in `harness-prompting-lessons.md` why a flat-args migration must re-key the registry arguments/examples.
- Rename `blockr.bi` references to `blockr.viz`; add a summary-table AI eval (5/5) and update drilldown eval scripts for the chart/table rename.