### PR TITLE
fix: CI hygiene + adopt core's formal block-arg registry accessors (#86)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^\.Rproj\.user$
 ^\.claude$
 ^dev$
+^benchmarks$

--- a/R/ai-ctrl-block.R
+++ b/R/ai-ctrl-block.R
@@ -135,13 +135,13 @@ skills_footer_ui <- function(x) {
     desc <- truncate_summary(s$description %||% "", 64)
     tags$li(
       tags$span(class = "blockr-skills-name", s$name),
-      if (nzchar(desc)) tags$span(class = "blockr-skills-desc", paste0(" — ", desc))
+      if (nzchar(desc)) tags$span(class = "blockr-skills-desc", paste0(" \u2014 ", desc))
     )
   })
   first <- skills[[1]]$name
 
   tagList(
-    tags$span(class = "blockr-action-sep", "·"),
+    tags$span(class = "blockr-action-sep", "\u00b7"),
     tags$span(
       class = "blockr-skills-link", tabindex = "0",
       "Skills",
@@ -149,7 +149,7 @@ skills_footer_ui <- function(x) {
         class = "blockr-skills-pop",
         tags$ul(class = "blockr-skills-pop-list", items),
         tags$div(class = "blockr-skills-pop-hint",
-                 sprintf("e.g. “use the %s skill to …”", first))
+                 sprintf("e.g. \u201cuse the %s skill to \u2026\u201d", first))
       )
     )
   )

--- a/R/harness-ellmer.R
+++ b/R/harness-ellmer.R
@@ -202,13 +202,8 @@ build_tool_system_prompt <- function(var_names, block,
     paste0("You are configuring a ", block_name, ".\n\n")
   }
 
-  param_docs_raw <- get_block_param_docs_raw(block_name)
-  block_prompt <- if (!is.null(param_docs_raw)) {
-    p <- attr(param_docs_raw, "prompt")
-    if (!is.null(p)) paste0(p, "\n\n") else ""
-  } else {
-    ""
-  }
+  guidance <- get_block_guidance(block_name)
+  block_prompt <- if (!is.null(guidance)) paste0(guidance, "\n\n") else ""
 
   helper_fns <- getOption("blockr.dplyr.summary_functions")
   helper_text <- if (!is.null(helper_fns) && length(helper_fns) > 0) {

--- a/R/param-schema.R
+++ b/R/param-schema.R
@@ -22,12 +22,18 @@ block_param_types <- function(block) {
   nms <- setdiff(names(fmls), "...")
   if (!length(nms)) return(NULL)
 
-  docs <- tryCatch(get_block_param_docs_raw(class(block)[1]), error = function(e) NULL)
+  block_name <- class(block)[1]
+  docs <- tryCatch(get_block_param_docs_raw(block_name), error = function(e) NULL)
   # The registry `examples` carry the author's canonical SHAPE for each param --
   # crucial when the formal default is uninformative (NULL, character(), list())
   # or ambiguous (an unnamed vector that is really a multi-value array, not enum
   # choices). Prefer the example's shape when present; fall back to the default.
   examples <- tryCatch(attr(docs, "examples"), error = function(e) NULL)
+  # The block author's DECLARED machine-readable type (core's `arg_*()`
+  # descriptor), when present, is authoritative -- it captures enums and
+  # arrays-of-records (the polymorphic fields example-inference can only
+  # approximate as a JSON string). Prefer it; fall back to inference otherwise.
+  spec <- tryCatch(get_block_arg_spec(block_name), error = function(e) NULL)
 
   types <- list()
   for (nm in nms) {
@@ -36,8 +42,15 @@ block_param_types <- function(block) {
     } else {
       nm
     }
+    declared <- if (!is.null(spec) && nm %in% names(spec)) {
+      tryCatch(blockr.core::block_arg_type(spec[[nm]]), error = function(e) NULL)
+    } else {
+      NULL
+    }
     types[[nm]] <- tryCatch(
-      if (!is.null(examples) && nm %in% names(examples) && !is.null(examples[[nm]])) {
+      if (!is.null(declared)) {
+        ellmer_type_from_descriptor(declared, desc)
+      } else if (!is.null(examples) && nm %in% names(examples) && !is.null(examples[[nm]])) {
         ellmer_type_from_value(examples[[nm]], desc)
       } else {
         ellmer_type_from_default(fmls[[nm]], desc)
@@ -47,6 +60,23 @@ block_param_types <- function(block) {
   }
 
   types
+}
+
+#' Bind a core `arg_*()` type descriptor (a JSON-Schema-subset list) to an ellmer
+#' type via `ellmer::type_from_schema()`. The descriptor is serialised to JSON
+#' text (the form `type_from_schema()` consumes); `desc` is attached and the
+#' field is marked optional so the model may omit it (partial configs are valid).
+#' @noRd
+ellmer_type_from_descriptor <- function(descriptor, desc = "") {
+  json <- as.character(
+    jsonlite::toJSON(descriptor, auto_unbox = TRUE, null = "null")
+  )
+  type <- ellmer::type_from_schema(text = json)
+  type@required <- FALSE
+  if (nzchar(desc)) {
+    type@description <- desc
+  }
+  type
 }
 
 #' @noRd

--- a/R/utils-llm.R
+++ b/R/utils-llm.R
@@ -252,12 +252,13 @@ data_schema.ggplot <- function(x, ...) {
 get_block_registry_info <- function(block_name) {
   tryCatch(
     {
-      meta <- blockr.core::registry_metadata(block_name,
+      meta <- blockr.core::block_metadata(block_name,
         fields = c("name", "description", "category"))
+      na_to_null <- function(x) if (length(x) && is.na(x[[1L]])) NULL else x[[1L]]
       list(
-        name = meta$name,
-        description = meta$description,
-        category = meta$category
+        name = na_to_null(meta$name),
+        description = na_to_null(meta$description),
+        category = na_to_null(meta$category)
       )
     },
     error = function(e) list(name = NULL, description = NULL, category = NULL)
@@ -265,25 +266,91 @@ get_block_registry_info <- function(block_name) {
 }
 
 
+#' Get the structured argument spec for a block type
+#'
+#' Returns the `block_args` object registered by the block author (via core's
+#' `block_meta_arguments()`), or `NULL`. Core normalizes legacy registrations
+#' (the old `structure(., examples=, prompt=)` form) into the same `block_args`
+#' shape, so this works for not-yet-migrated producers too.
+#'
+#' @param block_name Name of the block class
+#' @return A `block_args` object (possibly empty), or `NULL` on error
+#' @noRd
+get_block_arg_spec <- function(block_name) {
+  tryCatch(
+    blockr.core::block_meta_arguments(block_name),
+    error = function(e) NULL
+  )
+}
+
+
+#' Get the author's guidance (free-text construction hints) for a block type
+#'
+#' Replaces the legacy `attr(arguments, "prompt")` side-channel.
+#'
+#' @param block_name Name of the block class
+#' @return A guidance string, or NULL when none is registered
+#' @noRd
+get_block_guidance <- function(block_name) {
+  g <- tryCatch(
+    blockr.core::block_meta_guidance(block_name),
+    error = function(e) NULL
+  )
+  if (is.null(g) || length(g) == 0L || is.na(g[[1L]]) || !nzchar(g[[1L]])) {
+    return(NULL)
+  }
+  as.character(g[[1L]])
+}
+
+
+#' Get the assembled worked example for a block type
+#'
+#' Returns the first registered whole-block example configuration (a named list
+#' keyed by argument name), reconstructed from core's `block_meta_examples()`.
+#' This is the per-argument `example` assembly the block author registered.
+#'
+#' @param block_name Name of the block class
+#' @return A named list of example argument values, or NULL when none exist
+#' @noRd
+get_block_example <- function(block_name) {
+  ex <- tryCatch(
+    blockr.core::block_meta_examples(block_name),
+    error = function(e) NULL
+  )
+  if (is.null(ex) || length(ex) == 0L) return(NULL)
+  ex[[1L]]
+}
+
+
 #' Get raw parameter documentation vector for a block type
 #'
-#' Returns the named character vector from the registry with attributes intact,
-#' so that `generate_example_json()` can extract `example` attributes.
+#' Returns a named character vector of per-argument descriptions, carrying the
+#' worked `examples` (named list) and `prompt` (guidance) as attributes for the
+#' legacy call sites. Built from core's structured accessors, so no deprecated
+#' `registry_metadata()` call is made.
 #'
 #' @param block_name Name of the block
 #' @return Named character vector (with attributes) or NULL
 #' @noRd
 get_block_param_docs_raw <- function(block_name) {
-  args <- tryCatch(
-    blockr.core::registry_metadata(block_name, "arguments"),
-    error = function(e) NULL
-  )
-  # registry_metadata returns list(value) for list-type fields
-  if (is.list(args) && length(args) == 1L) args <- args[[1L]]
-  if (is.null(args) || length(args) == 0 || is.null(names(args))) {
+  args <- get_block_arg_spec(block_name)
+  if (is.null(args) || length(args) == 0L || is.null(names(args))) {
     return(NULL)
   }
-  args
+  nms <- names(args)
+  desc <- vapply(
+    nms,
+    function(nm) {
+      d <- blockr.core::block_arg_description(args[[nm]])
+      if (is.null(d)) "" else as.character(d)
+    },
+    character(1)
+  )
+  structure(
+    stats::setNames(desc, nms),
+    examples = get_block_example(block_name),
+    prompt = get_block_guidance(block_name)
+  )
 }
 
 

--- a/R/utils-llm.R
+++ b/R/utils-llm.R
@@ -56,7 +56,7 @@ data_schema.data.frame <- function(x, ...) {
 #   - gt_tbl / flextable / composed_*  -> blockr.sandbox (R/composer-ai-view.R)
 # blockr.ai itself carries ONLY data.frame / default / ggplot (below).
 #
-# WHY THIS MATTERS (this was a real bug — see #85): if you ALSO define
+# WHY THIS MATTERS (this was a real bug -- see #85): if you ALSO define
 # `data_schema.dm` here, BOTH packages call `S3method(data_schema, dm)` and the
 # winner is whichever namespace loaded LAST. In a deployed app blockr.dm loads
 # after blockr.ai, so blockr.ai's copy is silently shadowed and its edits do

--- a/tests/testthat/test-discover-errors.R
+++ b/tests/testthat/test-discover-errors.R
@@ -14,10 +14,12 @@ test_that("collect_block_errors reads the data-frame condition shape", {
 })
 
 test_that("collect_block_errors calls a reactive and tolerates empty/NULL", {
-  reactive_like <- function() data.frame(
-    phase = "eval", severity = "error", message = "undefined columns selected",
-    stringsAsFactors = FALSE
-  )
+  reactive_like <- function() {
+    data.frame(
+      phase = "eval", severity = "error", message = "undefined columns selected",
+      stringsAsFactors = FALSE
+    )
+  }
   expect_equal(collect_block_errors(reactive_like), "undefined columns selected")
 
   expect_equal(collect_block_errors(NULL), character())


### PR DESCRIPTION
This PR now carries **two** logically separate changes:

### 1. CI hygiene (original)
Follow-up to #87 (merged via admin override because CI was red). Makes `smoke` and `lint` pass:
- **non-ASCII WARNING**: `R/ai-ctrl-block.R` skill-UI glyphs → `\u` escapes; `R/utils-llm.R` comment em-dash → `--`.
- **top-level NOTE**: `benchmarks/` added to `.Rbuildignore`.
- **lint** (`brace_linter`): wrapped a multi-line test helper body in braces.

### 2. Adopt core's formal block-arg registry accessors (#86)
Consumer side of the block-arg registry migration. Reads block metadata via
blockr.core's formal accessors (`block_metadata()` / `block_meta_arguments()` /
`block_meta_examples()` / `block_meta_guidance()`) instead of the undocumented
`attr(arguments, "examples"/"prompt")` side-channel, and binds each block
author's **declared** `arg_*()` type via `ellmer::type_from_schema()` (falling
back to the old inference when no type is declared). Back-compatible — core
normalizes legacy registrations, so not-yet-migrated producers still work.

Files: `R/utils-llm.R`, `R/param-schema.R`, `R/harness-ellmer.R`.

The 7 producer packages are migrated in their own PRs (blockr.dplyr, .io, .viz,
.dm, .ggplot, .pharma, .extra). blockr.stats is a deferred follow-up.
