### PR TITLE
Bind whole input as `data` in the AI data-tool env

### DIFF
--- a/R/harness-tools.R
+++ b/R/harness-tools.R
@@ -22,6 +22,16 @@ build_harness_tools <- function(block, data, validate = NULL) {
   }
 
   datasets <- normalize_datasets(data)
+  # Also expose the WHOLE input under `data`, mirroring the block's fn (which
+  # receives the entire input as `data`). Without this, a dm input binds only
+  # the per-table names, so the model's natural probe -- `data[["adeftm"]]`,
+  # `str(data)`, `data$adeftm`, exactly as it must write the fn -- errors with
+  # "object 'data' not found". For a bare data.frame `normalize_datasets`
+  # already yields a single `data` entry, so only add it when absent (and never
+  # clobber a table literally named "data").
+  if (!is.null(data) && !"data" %in% names(datasets)) {
+    datasets <- c(list(data = data), datasets)
+  }
   data_tool <- if (length(datasets) > 0L) {
     new_data_tool(
       NULL, datasets,


### PR DESCRIPTION
## What

The block's `fn` receives the *entire* input as `data`, but the data-exploration
tool bound only per-table names for dm / multi-table inputs. The model's natural
probe (`data[["adeftm"]]`, `str(data)`, `data$adeftm`) — exactly how it must
write the `fn` — then errored with `object 'data' not found`.

This exposes the whole input under `data` in the data-tool env so probes mirror
the `fn`.

## How

In `build_harness_tools()`, after `normalize_datasets()`, prepend a `data` entry
holding the whole input:

- **bare data.frame** — `normalize_datasets()` already yields a single `data`
  entry, so the guard (`!"data" %in% names(datasets)`) skips it; no duplication.
- **dm / multi-table** — only per-table names were bound; now the whole input is
  also available as `data`.
- **NULL input** — the `!is.null(data)` guard skips it.
- Never clobbers a table literally named `data`.

## Test plan

- [ ] CI green