### PR TITLE
feat(discover): surface effect/noop in results, package-agnostic nudge, opt-in run log

### DIFF
--- a/R/ai-ctrl-block.R
+++ b/R/ai-ctrl-block.R
@@ -681,6 +681,8 @@ ai_ctrl_server <- function(id, x, vars, data, eval) {
         prompt = prompt,
         success = result$success,
         args = if (!is.null(result$args)) jsonlite::toJSON(result$args, auto_unbox = TRUE) else NULL,
+        effect = result$effect,
+        noop = result$noop,
         error = result$error,
         conversation = lapply(result$conversation %||% list(), function(m) {
           list(role = m$role, content = m$content)

--- a/R/discover.R
+++ b/R/discover.R
@@ -26,6 +26,10 @@
 #'   \item{success}{TRUE if args were discovered successfully}
 #'   \item{args}{List of discovered arguments}
 #'   \item{result}{The resulting object: data.frame, dm, ggplot, etc. (if successful)}
+#'   \item{effect}{What the applied config changed (see [data_effect()]); NULL
+#'     unless successful}
+#'   \item{noop}{TRUE when a config was applied but its effect was a no-op --
+#'     success alone does not mean the config did anything}
 #'   \item{error}{Error message (if failed)}
 #'   \item{conversation}{List of message exchanges (if verbose)}
 #'   \item{client}{The ellmer chat client (R6). Pass to subsequent calls to

--- a/R/harness-ellmer.R
+++ b/R/harness-ellmer.R
@@ -580,12 +580,16 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
   }
   reporter$end_phase("thinking")
 
+  n_probes <- if (!is.null(data_tool)) data_tool$probes_used() else NULL
+
   if (inherits(reply, "error")) {
     err <- paste0("LLM error: ", conditionMessage(reply))
     message("[discover] ", err)
     reporter$done(FALSE, err)
-    return(list(success = FALSE, args = NULL, conversation = conversation,
-                result = NULL, error = err, client = client))
+    res <- list(success = FALSE, args = NULL, conversation = conversation,
+                result = NULL, error = err, client = client)
+    log_discover_run(block_name, prompt, res, nudges = nudges, probes = n_probes)
+    return(res)
   }
 
   reply_text <- tryCatch(as.character(reply), error = function(e) "")
@@ -615,7 +619,7 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
   )
   message("[discover] done, success: ", success)
 
-  list(
+  res <- list(
     success = success,
     args = final_args,
     result = final_result,
@@ -635,4 +639,6 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
     question = if (!success && nzchar(reply_text)) reply_text else NULL,
     client = client
   )
+  log_discover_run(block_name, prompt, res, nudges = nudges, probes = n_probes)
+  res
 }

--- a/R/harness-ellmer.R
+++ b/R/harness-ellmer.R
@@ -588,6 +588,13 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
   final_result <- validate_tool$last_result()
   success <- !is.null(final_args)
 
+  # A config can be applied (success) yet have had no real effect -- the model
+  # may legitimately keep a no-op (e.g. a selector defaulting to "everything"),
+  # so success stays TRUE. But callers must be able to SEE that the effect was a
+  # no-op instead of trusting success alone, so both are part of the result.
+  final_effect <- if (success) validate_tool$last_effect() else NULL
+  final_noop <- success && effect_is_noop(final_effect)
+
   # The ACTUAL blocker (the last validation error) when the model failed. It was
   # previously discarded -- the model saw it in the tool loop but the result
   # reported NULL, so the user only got "cannot do this". Surface it now. It is
@@ -605,6 +612,8 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
     success = success,
     args = final_args,
     result = final_result,
+    effect = final_effect,
+    noop = final_noop,
     message = reply_text,
     conversation = conversation,
     # When the model failed, surface the real validation error (the blocker) --

--- a/R/harness-ellmer.R
+++ b/R/harness-ellmer.R
@@ -203,14 +203,20 @@ new_validate_tool <- function(validate, block, data = NULL) {
 
 #' Does an effect string indicate the config did nothing meaningful?
 #'
-#' Matches the explicit no-op signals only -- a data.frame that changed no rows
-#' or columns, or a composer/gt table still showing format placeholders ("NOT
-#' populated"). Deliberately does NOT match a bare "UNCHANGED" row count, since a
-#' same-row transform that adds/modifies a column is effective.
+#' Matches the explicit signals only -- a data.frame that changed no rows or
+#' columns, a table still showing format placeholders ("not populated"), or a
+#' result a [data_effect()] method marked "DEGENERATE" (computed but semantically
+#' empty, e.g. every value zero). Type-owning packages opt results into the noop
+#' nudge by putting one of these markers -- typically "DEGENERATE" -- in their
+#' effect string, ideally with a "hint:" naming the likely cause; the harness
+#' quotes the effect verbatim in the nudge. Deliberately does NOT match a bare
+#' "UNCHANGED" row count, since a same-row transform that adds/modifies a column
+#' is effective.
 #' @noRd
 effect_is_noop <- function(effect) {
   if (is.null(effect) || !nzchar(effect)) return(FALSE)
-  grepl("not populated|no rows or columns changed", effect, ignore.case = TRUE)
+  grepl("not populated|no rows or columns changed|degenerate", effect,
+        ignore.case = TRUE)
 }
 
 
@@ -559,15 +565,16 @@ discover_via_ellmer_tools <- function(prompt, block, data = NULL,
       )
     } else {
       paste0(
-        "Your last validate_config was VALID but had NO real effect (effect: ",
-        validate_tool$last_effect(), "). Usually that means it is not done: a ",
-        "composer table still showing 'xx.x' placeholders needs real data wired ",
-        "in (add `data =` to table() and `denominator = make_denom(...)`); a ",
-        "filter that removed 0 rows has the wrong condition. Fix it and call ",
-        "validate_config again. BUT if a no-op is genuinely what the request ",
-        "wants -- e.g. you exposed a selector that defaults to showing everything ",
-        "-- keep the config and reply in text saying so. Or say the block ",
-        "genuinely cannot do this."
+        "Your last validate_config was VALID but its effect signals a problem ",
+        "(effect: ", validate_tool$last_effect(), "). Usually that means it is ",
+        "not done: read the effect above -- if it names a cause or carries a ",
+        "hint, follow it; a skill for this block may also cover the failure ",
+        "mode. Diagnose with data_tool if needed, fix the config, and call ",
+        "validate_config again. BUT if this outcome is genuinely what the ",
+        "request wants -- e.g. you exposed a selector that defaults to showing ",
+        "everything, or the data really contains no such records -- keep the ",
+        "config and reply in text saying so. Or say the block genuinely cannot ",
+        "do this."
       )
     })
   }

--- a/R/run-log.R
+++ b/R/run-log.R
@@ -1,0 +1,47 @@
+# Persistent, structured record of discover runs. Every ad-hoc debugging
+# session so far has reconstructed this dataset by hand (report files, console
+# scrollback); logging it at the source makes recurring error signatures
+# minable and turns any interesting live failure into an eval case.
+
+#' Append one JSON line describing a discover run to the configured log
+#'
+#' Gated on `blockr_option("ai_run_log", "")` (option `blockr.ai_run_log` /
+#' env `BLOCKR_AI_RUN_LOG`): the path of a JSONL file to append to. Off by
+#' default; never throws -- telemetry must not be able to break discovery.
+#'
+#' @param block Block class name (character).
+#' @param prompt The user prompt.
+#' @param result The discover result list (`success`, `noop`, `effect`,
+#'   `error`, `question`).
+#' @param nudges Number of apply-nudges the harness issued.
+#' @param probes Number of data-tool probes used (NULL when no data tool).
+#' @return TRUE if a line was written, FALSE otherwise (invisibly).
+#' @noRd
+log_discover_run <- function(block, prompt, result, nudges = 0L, probes = NULL) {
+  path <- tryCatch(
+    blockr.core::blockr_option("ai_run_log", ""),
+    error = function(e) ""
+  )
+  if (!is.character(path) || length(path) != 1L || !nzchar(path)) {
+    return(invisible(FALSE))
+  }
+  tryCatch({
+    entry <- list(
+      ts = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z"),
+      block = block,
+      prompt = prompt,
+      success = isTRUE(result$success),
+      noop = isTRUE(result$noop),
+      effect = result$effect,
+      error = result$error,
+      question = !is.null(result$question),
+      nudges = nudges,
+      probes = probes
+    )
+    dir.create(dirname(path), showWarnings = FALSE, recursive = TRUE)
+    con <- file(path, open = "a", encoding = "UTF-8")
+    on.exit(close(con), add = TRUE)
+    writeLines(jsonlite::toJSON(entry, auto_unbox = TRUE, null = "null"), con)
+    invisible(TRUE)
+  }, error = function(e) invisible(FALSE))
+}

--- a/tests/testthat/helper-fakes.R
+++ b/tests/testthat/helper-fakes.R
@@ -1,0 +1,51 @@
+# Shared fakes for harness tests (test-harness-ellmer.R, test-run-log.R).
+# testthat sources helper-*.R before every test file.
+
+# A minimal block-like object: discover only needs attr(.,"ctor") for var names
+# and class() for (best-effort, NULL-tolerant) registry lookups.
+fake_block <- function(ctor = function(value = "x", ...) NULL) {
+  structure(list(), class = c("fake_block", "block"), ctor = ctor)
+}
+
+# A validate function independent of any real block/testServer: "good" succeeds
+# and returns a data.frame; anything else throws.
+good_validate <- function(args) {
+  if (identical(args$value, "good")) {
+    return(data.frame(a = 1:3, b = letters[1:3]))
+  }
+  stop("value must be 'good', got: ", args$value %||% "NULL")
+}
+
+# Fake ellmer chat client: replays a sequence of validate_config calls, then
+# returns final text. Implements only the methods the harness uses.
+make_fake_chat <- function(configs = character(), final_text = "Done.") {
+  tools <- NULL
+  list(
+    set_system_prompt = function(p) invisible(NULL),
+    set_tools = function(t) {
+      tools <<- t
+      invisible(NULL)
+    },
+    get_tools = function() tools,
+    chat = function(msg, ...) {
+      vt <- Find(function(td) isTRUE(td@name == "validate_config"), tools)
+      for (cfg in configs) {
+        if (!is.null(vt)) {
+          # Mimic the model: validate_config now takes the block's params as
+          # native arguments, so decode the JSON config and call with them.
+          args <- tryCatch(jsonlite::fromJSON(cfg, simplifyVector = FALSE),
+                           error = function(e) NULL)
+          if (is.list(args) && length(args)) do.call(vt, args) else vt(config = cfg)
+        }
+      }
+      final_text
+    }
+  )
+}
+
+with_fake_chat <- function(chat, expr) {
+  withr::with_options(
+    list(blockr.chat_function = list("gpt-4o-mini" = function() chat)),
+    expr
+  )
+}

--- a/tests/testthat/test-effect.R
+++ b/tests/testthat/test-effect.R
@@ -170,3 +170,21 @@ test_that("effect_primary_df picks the right input", {
   expect_null(effect_primary_df(structure(list(), class = "dm")))
   expect_null(effect_primary_df(NULL))
 })
+
+# --- noop detection (drives the harness nudge loop) ---------------------------
+
+test_that("effect_is_noop matches the explicit no-op and degeneracy markers", {
+  # data.frame no-op and unpopulated-table signals
+  expect_true(effect_is_noop("rows: 32 -> 32 (UNCHANGED); no rows or columns changed"))
+  expect_true(effect_is_noop("NOT populated: 4 cell(s) still show format placeholders"))
+  # a data_effect method can opt a computed-but-empty result into the nudge
+  expect_true(effect_is_noop(
+    "populated but DEGENERATE: every numeric value is zero; hint: check factors"
+  ))
+
+  # a bare UNCHANGED row count is NOT a no-op (a same-row mutate is effective)
+  expect_false(effect_is_noop("rows: 32 -> 32 (UNCHANGED); columns modified: mpg"))
+  expect_false(effect_is_noop("populated: real numbers present (12 of 20 non-empty cells)"))
+  expect_false(effect_is_noop(NULL))
+  expect_false(effect_is_noop(""))
+})

--- a/tests/testthat/test-harness-ellmer.R
+++ b/tests/testthat/test-harness-ellmer.R
@@ -5,54 +5,8 @@
 # `blockr.chat_function` option hook, so the whole tool-call loop is
 # deterministic.
 
-# A minimal block-like object: discover only needs attr(.,"ctor") for var names
-# and class() for (best-effort, NULL-tolerant) registry lookups.
-fake_block <- function(ctor = function(value = "x", ...) NULL) {
-  structure(list(), class = c("fake_block", "block"), ctor = ctor)
-}
-
-# A validate function independent of any real block/testServer: "good" succeeds
-# and returns a data.frame; anything else throws.
-good_validate <- function(args) {
-  if (identical(args$value, "good")) {
-    return(data.frame(a = 1:3, b = letters[1:3]))
-  }
-  stop("value must be 'good', got: ", args$value %||% "NULL")
-}
-
-# Fake ellmer chat client: replays a sequence of validate_config calls, then
-# returns final text. Implements only the methods the harness uses.
-make_fake_chat <- function(configs = character(), final_text = "Done.") {
-  tools <- NULL
-  list(
-    set_system_prompt = function(p) invisible(NULL),
-    set_tools = function(t) {
-      tools <<- t
-      invisible(NULL)
-    },
-    get_tools = function() tools,
-    chat = function(msg, ...) {
-      vt <- Find(function(td) isTRUE(td@name == "validate_config"), tools)
-      for (cfg in configs) {
-        if (!is.null(vt)) {
-          # Mimic the model: validate_config now takes the block's params as
-          # native arguments, so decode the JSON config and call with them.
-          args <- tryCatch(jsonlite::fromJSON(cfg, simplifyVector = FALSE),
-                           error = function(e) NULL)
-          if (is.list(args) && length(args)) do.call(vt, args) else vt(config = cfg)
-        }
-      }
-      final_text
-    }
-  )
-}
-
-with_fake_chat <- function(chat, expr) {
-  withr::with_options(
-    list(blockr.chat_function = list("gpt-4o-mini" = function() chat)),
-    expr
-  )
-}
+# fake_block / good_validate / make_fake_chat / with_fake_chat live in
+# helper-fakes.R (shared with test-run-log.R).
 
 
 test_that("new_validate_tool: valid config returns ok + preview and records args", {

--- a/tests/testthat/test-harness-ellmer.R
+++ b/tests/testthat/test-harness-ellmer.R
@@ -189,6 +189,57 @@ test_that("ellmer harness: retries past a bad config and applies the good one", 
   expect_null(res$error)
 })
 
+test_that("ellmer harness: result carries the effect and flags a persistent no-op", {
+  # Validator returns the input unchanged -> every applied config is a no-op.
+  # The fake chat never "fixes" it, so the nudge cap is hit and the result must
+  # say so: success (a config IS applied) but noop=TRUE with the effect visible.
+  chat <- make_fake_chat(
+    configs = '{"value": "good"}',
+    final_text = "Applied."
+  )
+
+  res <- with_fake_chat(chat, {
+    discover_via_ellmer_tools(
+      prompt = "do nothing much",
+      block = fake_block(),
+      data = iris,
+      validate = function(args) iris
+    )
+  })
+
+  expect_true(res$success)
+  expect_true(res$noop)
+  expect_match(res$effect, "no rows or columns changed")
+
+  # An effective config reports its effect and noop=FALSE.
+  chat2 <- make_fake_chat(configs = '{"value": "good"}', final_text = "Done.")
+  res2 <- with_fake_chat(chat2, {
+    discover_via_ellmer_tools(
+      prompt = "setosa only",
+      block = fake_block(),
+      data = iris,
+      validate = function(args) iris[iris$Species == "setosa", ]
+    )
+  })
+  expect_true(res2$success)
+  expect_false(res2$noop)
+  expect_match(res2$effect, "100 removed")
+
+  # No config applied -> effect NULL, noop FALSE.
+  chat3 <- make_fake_chat(configs = character(), final_text = "Which column?")
+  res3 <- with_fake_chat(chat3, {
+    discover_via_ellmer_tools(
+      prompt = "fix it",
+      block = fake_block(),
+      data = iris,
+      validate = function(args) iris
+    )
+  })
+  expect_false(res3$success)
+  expect_null(res3$effect)
+  expect_false(res3$noop)
+})
+
 test_that("ellmer harness: no validate call -> failure with the reply as question", {
   chat <- make_fake_chat(
     configs = character(),

--- a/tests/testthat/test-run-log.R
+++ b/tests/testthat/test-run-log.R
@@ -1,0 +1,75 @@
+# Telemetry: one JSON line per discover run, gated on blockr.ai_run_log.
+
+test_that("discover appends a JSONL entry when ai_run_log is set", {
+  log <- withr::local_tempfile(fileext = ".jsonl")
+  withr::local_options(blockr.ai_run_log = log)
+
+  chat <- make_fake_chat(configs = '{"value": "good"}', final_text = "Done.")
+  res <- with_fake_chat(chat, {
+    discover_via_ellmer_tools(
+      prompt = "setosa only",
+      block = fake_block(),
+      data = iris,
+      validate = function(args) iris[iris$Species == "setosa", ]
+    )
+  })
+  expect_true(res$success)
+
+  lines <- readLines(log, warn = FALSE)
+  expect_length(lines, 1L)
+  entry <- jsonlite::fromJSON(lines[1L])
+  expect_identical(entry$block, "fake_block")
+  expect_identical(entry$prompt, "setosa only")
+  expect_true(entry$success)
+  expect_false(entry$noop)
+  expect_match(entry$effect, "100 removed")
+  expect_identical(entry$nudges, 0L)
+
+  # A second run appends (JSONL, not overwrite), and a no-config run logs the
+  # failure shape.
+  chat2 <- make_fake_chat(configs = character(), final_text = "Which column?")
+  with_fake_chat(chat2, {
+    discover_via_ellmer_tools(
+      prompt = "fix it",
+      block = fake_block(),
+      data = iris,
+      validate = function(args) iris
+    )
+  })
+  lines <- readLines(log, warn = FALSE)
+  expect_length(lines, 2L)
+  entry2 <- jsonlite::fromJSON(lines[2L])
+  expect_false(entry2$success)
+  expect_true(entry2$question)
+})
+
+test_that("no log option means no file and no error", {
+  withr::local_options(blockr.ai_run_log = NULL)
+  withr::local_envvar(BLOCKR_AI_RUN_LOG = "")
+
+  chat <- make_fake_chat(configs = '{"value": "good"}', final_text = "Done.")
+  res <- with_fake_chat(chat, {
+    discover_via_ellmer_tools(
+      prompt = "x",
+      block = fake_block(),
+      data = NULL,
+      validate = function(args) data.frame(a = 1)
+    )
+  })
+  expect_true(res$success)
+})
+
+test_that("an unwritable log path never breaks discovery", {
+  withr::local_options(blockr.ai_run_log = "/nonexistent-root/nope/run.jsonl")
+
+  chat <- make_fake_chat(configs = '{"value": "good"}', final_text = "Done.")
+  res <- with_fake_chat(chat, {
+    discover_via_ellmer_tools(
+      prompt = "x",
+      block = fake_block(),
+      data = NULL,
+      validate = function(args) data.frame(a = 1)
+    )
+  })
+  expect_true(res$success)
+})


### PR DESCRIPTION
Makes `discover()` runs observable and debuggable, and decouples the noop-nudge
loop from any specific block package. Three focused commits:

### 1. Surface `effect` + `noop` in the result instead of bare `success`
A config can be applied (`success=TRUE`) yet have had **no real effect** — when
the model exhausts the noop nudges, or legitimately keeps a no-op (e.g. a
selector defaulting to "everything"). The structured result now carries:
- `effect` — the `data_effect`/`config_effect` string of the applied config
- `noop` — `effect_is_noop()` of it

The ai-ctrl report records both per prompt, so callers can finally tell an
effective config from a silent no-op.

### 2. Make the noop nudge package-agnostic + recognise `DEGENERATE` effects
The nudge previously hardcoded composer remediation (`add data= to table()`,
`make_denom(...)`) inside the generic harness — blockr.ai has no business
knowing composer exists, and blocks from packages that register their own
`data_effect` methods got advice about a package they don't use.

The nudge now quotes the effect string verbatim and tells the model to follow
the cause/hint it carries; domain remediation belongs in the type-owning
package's `data_effect` method (same extension point as `data_schema`) or in a
skill. `effect_is_noop()` additionally matches a `DEGENERATE` marker, so a
method can opt a computed-but-semantically-empty result (e.g. every count zero)
into the nudge loop.

### 3. Option-gated JSONL telemetry for every discover run
Every debugging session so far reconstructed run history by hand. Setting
`blockr.ai_run_log` (option, or `BLOCKR_AI_RUN_LOG` env) to a file path now
appends one JSON line per discover run: timestamp, block class, prompt,
success, noop, effect, error, whether the model asked a question, nudge count,
and data-probe count.

**Off by default**; writing is `tryCatch`-guarded end to end so telemetry can
never break discovery (covered by an unwritable-path test). This is the
feedstock for mining recurring error signatures and turning live failures into
eval cases.

Test fakes moved to `helper-fakes.R` so both harness test files share them.